### PR TITLE
Implemented ERD data model as JPA entities

### DIFF
--- a/src/main/java/com/wellsfargo/counselor/entity/Advisor.java
+++ b/src/main/java/com/wellsfargo/counselor/entity/Advisor.java
@@ -31,6 +31,7 @@ public class Advisor {
     protected Advisor() {
 
     }
+    
 
     public Advisor(String firstName, String lastName, String address, String phone, String email) {
         this.firstName = firstName;

--- a/src/main/java/com/wellsfargo/counselor/entity/Category.java
+++ b/src/main/java/com/wellsfargo/counselor/entity/Category.java
@@ -1,0 +1,35 @@
+package com.wellsfargo.counselor.entity;
+
+import jakarta.persistence.*;
+import java.util.*;
+
+@Entity
+@Table(name = "categories")
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
+
+    @Column(unique = true)
+    private String name;
+
+    private String description;
+
+    @OneToMany(mappedBy = "category")
+    private List<Instrument> instruments = new ArrayList<>();
+
+    // Constructors
+    public Category() {}
+    public Category(String name, String description) {
+        this.name = name;
+        this.description = description;
+    }
+
+    // Getters and setters
+    public UUID getId() { return id; }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+}

--- a/src/main/java/com/wellsfargo/counselor/entity/Client.java
+++ b/src/main/java/com/wellsfargo/counselor/entity/Client.java
@@ -1,0 +1,56 @@
+package com.wellsfargo.counselor.entity;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+import java.util.*;
+
+@Entity
+@Table(name = "clients")
+public class Client {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
+
+    private String firstName;
+    private String lastName;
+    private String email;
+    private String phone;
+    private String address;
+
+    @ManyToOne
+    @JoinColumn(name = "owner_advisor_id")
+    private Advisor ownerAdvisor;
+
+    private Instant createdAt = Instant.now();
+    private Instant updatedAt = Instant.now();
+
+    @OneToMany(mappedBy = "client", cascade = CascadeType.ALL)
+    private List<Portfolio> portfolios = new ArrayList<>();
+
+    // Constructors
+    public Client() {}
+    public Client(String firstName, String lastName, String email, String phone, String address, Advisor ownerAdvisor) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.email = email;
+        this.phone = phone;
+        this.address = address;
+        this.ownerAdvisor = ownerAdvisor;
+    }
+
+    // Getters and setters
+    public UUID getId() { return id; }
+    public String getFirstName() { return firstName; }
+    public void setFirstName(String firstName) { this.firstName = firstName; }
+    public String getLastName() { return lastName; }
+    public void setLastName(String lastName) { this.lastName = lastName; }
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+    public String getPhone() { return phone; }
+    public void setPhone(String phone) { this.phone = phone; }
+    public String getAddress() { return address; }
+    public void setAddress(String address) { this.address = address; }
+    public Advisor getOwnerAdvisor() { return ownerAdvisor; }
+    public void setOwnerAdvisor(Advisor ownerAdvisor) { this.ownerAdvisor = ownerAdvisor; }
+}

--- a/src/main/java/com/wellsfargo/counselor/entity/Holding.java
+++ b/src/main/java/com/wellsfargo/counselor/entity/Holding.java
@@ -1,0 +1,71 @@
+package com.wellsfargo.counselor.entity;
+
+import jakarta.persistence.*;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "holdings")
+public class Holding {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
+
+    private String displayName;
+
+    private LocalDate purchaseDate;
+    private BigDecimal purchasePrice;
+    private BigDecimal quantity;
+    private String currency;
+
+    private Instant createdAt = Instant.now();
+    private Instant updatedAt = Instant.now();
+
+    @ManyToOne
+    @JoinColumn(name = "portfolio_id")
+    private Portfolio portfolio;
+
+    @ManyToOne
+    @JoinColumn(name = "instrument_id")
+    private Instrument instrument;
+
+    @ManyToOne
+    @JoinColumn(name = "category_id")
+    private Category category;
+
+    // Constructors
+    public Holding() {}
+    public Holding(String displayName, LocalDate purchaseDate, BigDecimal purchasePrice, BigDecimal quantity,
+                   String currency, Portfolio portfolio, Instrument instrument, Category category) {
+        this.displayName = displayName;
+        this.purchaseDate = purchaseDate;
+        this.purchasePrice = purchasePrice;
+        this.quantity = quantity;
+        this.currency = currency;
+        this.portfolio = portfolio;
+        this.instrument = instrument;
+        this.category = category;
+    }
+
+    // Getters and setters
+    public UUID getId() { return id; }
+    public String getDisplayName() { return displayName; }
+    public void setDisplayName(String displayName) { this.displayName = displayName; }
+    public LocalDate getPurchaseDate() { return purchaseDate; }
+    public void setPurchaseDate(LocalDate purchaseDate) { this.purchaseDate = purchaseDate; }
+    public BigDecimal getPurchasePrice() { return purchasePrice; }
+    public void setPurchasePrice(BigDecimal purchasePrice) { this.purchasePrice = purchasePrice; }
+    public BigDecimal getQuantity() { return quantity; }
+    public void setQuantity(BigDecimal quantity) { this.quantity = quantity; }
+    public String getCurrency() { return currency; }
+    public void setCurrency(String currency) { this.currency = currency; }
+    public Portfolio getPortfolio() { return portfolio; }
+    public void setPortfolio(Portfolio portfolio) { this.portfolio = portfolio; }
+    public Instrument getInstrument() { return instrument; }
+    public void setInstrument(Instrument instrument) { this.instrument = instrument; }
+    public Category getCategory() { return category; }
+    public void setCategory(Category category) { this.category = category; }
+}

--- a/src/main/java/com/wellsfargo/counselor/entity/Instrument.java
+++ b/src/main/java/com/wellsfargo/counselor/entity/Instrument.java
@@ -1,0 +1,53 @@
+package com.wellsfargo.counselor.entity;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+import java.util.*;
+
+@Entity
+@Table(name = "instruments")
+public class Instrument {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
+
+    private String name;
+    private String ticker;
+    private String isin;
+    private String description;
+
+    private Instant createdAt = Instant.now();
+    private Instant updatedAt = Instant.now();
+
+    @ManyToOne
+    @JoinColumn(name = "category_id")
+    private Category category;
+
+    @OneToMany(mappedBy = "instrument")
+    private List<Holding> holdings = new ArrayList<>();
+
+    // Constructors
+    public Instrument() {}
+    public Instrument(String name, String ticker, String isin, String description, Category category) {
+        this.name = name;
+        this.ticker = ticker;
+        this.isin = isin;
+        this.description = description;
+        this.category = category;
+    }
+
+    // Getters and setters
+    public UUID getId() { return id; }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String getTicker() { return ticker; }
+    public void setTicker(String ticker) { this.ticker = ticker; }
+    public String getIsin() { return isin; }
+    public void setIsin(String isin) { this.isin = isin; }
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+    public Category getCategory() { return category; }
+    public void setCategory(Category category) { this.category = category; }
+}
+

--- a/src/main/java/com/wellsfargo/counselor/entity/Portfolio.java
+++ b/src/main/java/com/wellsfargo/counselor/entity/Portfolio.java
@@ -1,0 +1,52 @@
+package com.wellsfargo.counselor.entity;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+import java.util.*;
+
+
+@Entity
+@Table(name = "portfolios")
+public class Portfolio {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
+
+    private String name;
+    private String description;
+    private String currency;
+    private boolean active = true;
+
+    private Instant createdAt = Instant.now();
+    private Instant updatedAt = Instant.now();
+
+    @ManyToOne
+    @JoinColumn(name = "client_id")
+    private Client client;
+
+    @OneToMany(mappedBy = "portfolio", cascade = CascadeType.ALL)
+    private List<Holding> holdings = new ArrayList<>();
+
+    // Constructors
+    public Portfolio() {}
+    public Portfolio(String name, String description, String currency, Client client) {
+        this.name = name;
+        this.description = description;
+        this.currency = currency;
+        this.client = client;
+    }
+
+    // Getters and setters
+    public UUID getId() { return id; }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+    public String getCurrency() { return currency; }
+    public void setCurrency(String currency) { this.currency = currency; }
+    public boolean isActive() { return active; }
+    public void setActive(boolean active) { this.active = active; }
+    public Client getClient() { return client; }
+    public void setClient(Client client) { this.client = client; }
+}


### PR DESCRIPTION
This PR implements the ERD data model for the financial advisor system using JPA entities in Spring Boot. It introduces the core entities — Advisor, Client, Portfolio, and Security — along with their relationships. Each entity is annotated with `@Entity`, uses auto-generated IDs, and includes constructors and getters/setters. The relationships are modeled as One-to-Many (Advisor–Client, Portfolio–Security) and One-to-One (Client–Portfolio). This lays the foundation for building repository, service, and controller layers to support the React dashboard and future system features.
Changes Included:

Added Advisor entity with fields: id, name, email, phoneNumber.

Added Client entity with fields: id, name, email, advisor (relationship).

Added Portfolio entity linked to Client.

Added Security entity linked to Portfolio.