### PR TITLE
Implemented JPA data model for investment system

### DIFF
--- a/src/main/java/com/wellsfargo/counselor/entities/Client.java
+++ b/src/main/java/com/wellsfargo/counselor/entities/Client.java
@@ -1,0 +1,103 @@
+package com.wellsfargo.counselor.entities;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+
+@Entity
+public class Client {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long clientId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "advisor_id", nullable = false)
+    private FinancialAdvisor advisor;
+
+    @Column(nullable = false)
+    private String firstName;
+
+    @Column(nullable = false)
+    private String lastName;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String phoneNumber;
+
+    @OneToOne(mappedBy = "client", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private Portfolio portfolio;
+
+    protected Client() {
+    }
+
+    public Client(FinancialAdvisor advisor, String firstName, String lastName, String email, String phoneNumber, Portfolio portfolio) {
+        this.advisor = advisor;
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.email = email;
+        this.phoneNumber = phoneNumber;
+        this.portfolio = portfolio;
+    }
+
+    public Long getClientId() {
+        return clientId;
+    }
+
+    public FinancialAdvisor getAdvisor() {
+        return advisor;
+    }
+
+    public void setAdvisor(FinancialAdvisor advisor) {
+        this.advisor = advisor;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+
+    public void setPhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
+    public Portfolio getPortfolio() {
+        return portfolio;
+    }
+
+    public void setPortfolio(Portfolio portfolio) {
+        this.portfolio = portfolio;
+    }
+}

--- a/src/main/java/com/wellsfargo/counselor/entities/FinancialAdvisor.java
+++ b/src/main/java/com/wellsfargo/counselor/entities/FinancialAdvisor.java
@@ -1,0 +1,91 @@
+package com.wellsfargo.counselor.entities;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class FinancialAdvisor {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long advisorId;
+
+    @Column(nullable = false)
+    private String firstName;
+
+    @Column(nullable = false)
+    private String lastName;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String phoneNumber;
+
+    @OneToMany(mappedBy = "advisor", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Client> clients = new ArrayList<>();
+
+    protected FinancialAdvisor() {
+    }
+
+    public FinancialAdvisor(String firstName, String lastName, String email, String phoneNumber, List<Client> clients) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.email = email;
+        this.phoneNumber = phoneNumber;
+        this.clients = clients;
+    }
+
+    public Long getAdvisorId() {
+        return advisorId;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+
+    public void setPhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
+    public List<Client> getClients() {
+        return clients;
+    }
+
+    public void setClients(List<Client> clients) {
+        this.clients = clients;
+    }
+}

--- a/src/main/java/com/wellsfargo/counselor/entities/Portfolio.java
+++ b/src/main/java/com/wellsfargo/counselor/entities/Portfolio.java
@@ -1,0 +1,57 @@
+package com.wellsfargo.counselor.entities;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class Portfolio {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long portfolioId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "client_id", nullable = false)
+    private Client client;
+
+    @OneToMany(mappedBy = "portfolio", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Security> securities = new ArrayList<>();
+
+    protected Portfolio() {
+    }
+
+    public Portfolio(Client client, List<Security> securities) {
+        this.client = client;
+        this.securities = securities;
+    }
+
+    public Long getPortfolioId() {
+        return portfolioId;
+    }
+
+    public Client getClient() {
+        return client;
+    }
+
+    public void setClient(Client client) {
+        this.client = client;
+    }
+
+    public List<Security> getSecurities() {
+        return securities;
+    }
+
+    public void setSecurities(List<Security> securities) {
+        this.securities = securities;
+    }
+}

--- a/src/main/java/com/wellsfargo/counselor/entities/Security.java
+++ b/src/main/java/com/wellsfargo/counselor/entities/Security.java
@@ -1,0 +1,104 @@
+package com.wellsfargo.counselor.entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Entity
+public class Security {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long securityId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "portfolio_id", nullable = false)
+    private Portfolio portfolio;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String category;
+
+    @Column(nullable = false)
+    private LocalDate purchaseDate;
+
+    @Column(nullable = false)
+    private BigDecimal purchasePrice;
+
+    @Column(nullable = false)
+    private Integer quantity;
+
+    protected Security() {
+    }
+
+    public Security(Portfolio portfolio, String name, String category, LocalDate purchaseDate, BigDecimal purchasePrice, Integer quantity) {
+        this.portfolio = portfolio;
+        this.name = name;
+        this.category = category;
+        this.purchaseDate = purchaseDate;
+        this.purchasePrice = purchasePrice;
+        this.quantity = quantity;
+    }
+
+    public Long getSecurityId() {
+        return securityId;
+    }
+
+    public Portfolio getPortfolio() {
+        return portfolio;
+    }
+
+    public void setPortfolio(Portfolio portfolio) {
+        this.portfolio = portfolio;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public void setCategory(String category) {
+        this.category = category;
+    }
+
+    public LocalDate getPurchaseDate() {
+        return purchaseDate;
+    }
+
+    public void setPurchaseDate(LocalDate purchaseDate) {
+        this.purchaseDate = purchaseDate;
+    }
+
+    public BigDecimal getPurchasePrice() {
+        return purchasePrice;
+    }
+
+    public void setPurchasePrice(BigDecimal purchasePrice) {
+        this.purchasePrice = purchasePrice;
+    }
+
+    public Integer getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(Integer quantity) {
+        this.quantity = quantity;
+    }
+}


### PR DESCRIPTION
This pull request introduces the core JPA entity classes for the application's domain model, establishing the foundational data structure and relationships for a financial advising system. The changes define entities for financial advisors, clients, portfolios, and securities, including their fields, constructors, and JPA relationship mappings.

**Entity Model Introduction and Relationships:**

- Added the `FinancialAdvisor` entity, including basic advisor information and a one-to-many relationship to `Client` entities.
- Added the `Client` entity, including personal details, a many-to-one relationship to `FinancialAdvisor`, and a one-to-one relationship with `Portfolio`.
- Added the `Portfolio` entity, representing a client's investment portfolio, with a one-to-one relationship to `Client` and a one-to-many relationship to `Security`.
- Added the `Security` entity, representing individual investments, with fields for name, category, purchase details, and a many-to-one relationship to `Portfolio`.